### PR TITLE
Outline Fixing

### DIFF
--- a/equalizer.scss
+++ b/equalizer.scss
@@ -5,8 +5,11 @@ $equalizer-grey: #999;
   box-sizing: border-box;
   font-family: sans-serif;
   margin: 0;
-  outline: none;
   padding: 0;
+  
+  &:focus {
+    outline: none;
+  }
 }
 
 h1,

--- a/equalizer.scss
+++ b/equalizer.scss
@@ -5,6 +5,7 @@ $equalizer-grey: #999;
   box-sizing: border-box;
   font-family: sans-serif;
   margin: 0;
+  outline: none;
   padding: 0;
 }
 
@@ -28,10 +29,6 @@ textarea {
   font-weight: 400;
   line-height: 14px;
   margin: 0;
-
-  &:focus {
-    outline: none;
-  }
 }
 
 select {


### PR DESCRIPTION
## Summary

Adding outline Fixing to equalizer, how it was before, it doesn't include all tags like div or img, allowing them to have outline when you made it clickable.
