### PR TITLE
remove inline block from text tags

### DIFF
--- a/equalizer.css
+++ b/equalizer.css
@@ -19,7 +19,7 @@ a,
 button,
 select,
 textarea {
-  color: #000000;
+  color: #333333;
   font-size: 14px;
   font-weight: 400;
   line-height: 14px;
@@ -80,7 +80,7 @@ a {
   text-decoration: none;
 }
 a:focus, a:active {
-  color: #000000;
+  color: #333333;
   text-decoration: none;
 }
 

--- a/equalizer.css
+++ b/equalizer.css
@@ -19,7 +19,7 @@ a,
 button,
 select,
 textarea {
-  color: #333333;
+  color: #333;
   font-size: 14px;
   font-weight: 400;
   line-height: 14px;
@@ -80,7 +80,7 @@ a {
   text-decoration: none;
 }
 a:focus, a:active {
-  color: #333333;
+  color: #333;
   text-decoration: none;
 }
 

--- a/equalizer.css
+++ b/equalizer.css
@@ -19,8 +19,7 @@ a,
 button,
 select,
 textarea {
-  color: #717171;
-  display: inline-block;
+  color: #000000;
   font-size: 14px;
   font-weight: 400;
   line-height: 14px;
@@ -81,7 +80,7 @@ a {
   text-decoration: none;
 }
 a:focus, a:active {
-  color: #717171;
+  color: #000000;
   text-decoration: none;
 }
 

--- a/equalizer.scss
+++ b/equalizer.scss
@@ -12,20 +12,13 @@ $equalizer-grey: #999;
   }
 }
 
-%text-base {
-  color: $equalizer-black;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 14px;
-  margin: 0;
-}
-
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
+p,
 span,
 label,
 input,
@@ -33,12 +26,11 @@ a,
 button,
 select,
 textarea {
-  @extend %text-base;
-  display: inline-block;
-}
-
-p {
-  @extend %text-base;
+  color: $equalizer-black;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 14px;
+  margin: 0;
 }
 
 select {

--- a/equalizer.scss
+++ b/equalizer.scss
@@ -12,13 +12,20 @@ $equalizer-grey: #999;
   }
 }
 
+%text-base {
+  color: $equalizer-black;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 14px;
+  margin: 0;
+}
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-p,
 span,
 label,
 input,
@@ -26,12 +33,12 @@ a,
 button,
 select,
 textarea {
-  color: $equalizer-black;
+  @extend %text-base;
   display: inline-block;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 14px;
-  margin: 0;
+}
+
+p {
+  @extend %text-base;
 }
 
 select {

--- a/equalizer.scss
+++ b/equalizer.scss
@@ -1,4 +1,4 @@
-$equalizer-black: #717171;
+$equalizer-black: #000;
 $equalizer-grey: #999;
 
 * {

--- a/equalizer.scss
+++ b/equalizer.scss
@@ -1,4 +1,4 @@
-$equalizer-black: #000;
+$equalizer-black: #333;
 $equalizer-grey: #999;
 
 * {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolox-equalizer",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Wolox scss bootstrap equalizer.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolox-equalizer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Wolox scss bootstrap equalizer.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Inline block is causing problems when we need to form a paragraph with different styles on it, for example:

```pug
p.text-normal.black
  | Some normal text
  span.text-normal.black.italic
    | this part is italic
  | continue with normal text
  span.text-normal.black.bold
    | and this is bold
```

With `inline-block`, the texts are being display as a "column" rather than normal text

